### PR TITLE
Fix: resolve Zizmor template and pin findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -78,7 +78,7 @@ runs:
       id: export-env-variables
       if: ${{ inputs.env-vars != '{}' }}
       # yamllint disable-line rule:line-length
-      uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
+      uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # 2.0.0
       with:
         secrets: ${{ inputs.env-vars }}
 
@@ -86,7 +86,7 @@ runs:
       id: export-env-secrets
       if: ${{ inputs.env-secrets != '{}' }}
       # yamllint disable-line rule:line-length
-      uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
+      uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # 2.0.0
       with:
         secrets: ${{ inputs.env-secrets }}
 
@@ -95,11 +95,15 @@ runs:
       shell: bash
       env:
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        INPUT_MAKE_TARGETS: ${{ inputs.make-targets }}
       # yamllint disable rule:line-length
       run: |
         # Build Maven project with Make
         cd "${INPUT_PATH_PREFIX}"
-        make ${{ inputs.make-targets }}
+        # Intentionally unquoted: make-targets may name several targets
+        # that must word-split into separate arguments.
+        # shellcheck disable=SC2086
+        make ${INPUT_MAKE_TARGETS}
 
     # yamllint enable rule:line-length
     - name: Generate JaCoCo Badge


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported a `template-injection`
finding and two `ref-version-mismatch` findings in this composite
action. This change resolves all of them, bringing the action to zero
medium-or-higher findings.

### Changes

- **template-injection (make_targets):** the build step interpolated
  `${{ inputs.make_targets }}` directly into the bash `run` block. It is
  now routed through a per-step `env:` block (`INPUT_MAKE_TARGETS`) so
  nothing user-controlled is expanded into a run body. The value is
  intentionally left unquoted in the `make` invocation to preserve
  multi-target word splitting, documented with an inline `shellcheck`
  disable and rationale.

- **ref-version-mismatch (vars-to-env-action):** both pins carried a
  `# v2.0.0` comment, but the upstream tag is named `2.0.0` with no
  leading `v`, so the comment did not match any real ref. Both comments
  are corrected to `# 2.0.0` to match the commit-pinned tag.

### Impact

No behavioural change.
