### PR TITLE
Feat: Add outputs, summary and artifact upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,35 +37,51 @@ steps:
 
 <!-- markdownlint-disable MD013 -->
 
-| Name         | Required | Default   | Description                           |
-| ------------ | -------- | --------- | ------------------------------------- |
-| path_prefix  | False    | "."       | Directory location containing project |
-|              |          |           | code                                  |
-| jdk-version  | False    | "17"      | OpenJDK version to set up             |
-| distribution | False    | "temurin" | OpenJDK distribution                  |
-| mvn-version  | False    | "3.8.2"   | Maven version to set up               |
-| make-targets | False    | "all"     | Targets for the make command (e.g.,   |
-|              |          |           | "clean compile test")                 |
-| env-vars     | False    | "{}"      | Pass GitHub variables as environment  |
-|              |          |           | variables via `toJSON(vars)` or       |
-|              |          |           | specific variables in JSON            |
-| env-secrets  | False    | "{}"      | Pass GitHub secrets as environment    |
-|              |          |           | variables via `toJSON(secrets)` or    |
-|              |          |           | specific secrets in JSON              |
-| run-jacoco   | False    | "true"    | Boolean defining whether JaCoCo       |
-|              |          |           | coverage reporting runs               |
+| Name            | Required | Default   | Description                           |
+| --------------- | -------- | --------- | ------------------------------------- |
+| path_prefix     | False    | "."       | Directory location containing project |
+|                 |          |           | code                                  |
+| jdk-version     | False    | "17"      | OpenJDK version to set up             |
+| distribution    | False    | "temurin" | OpenJDK distribution                  |
+| mvn-version     | False    | "3.8.2"   | Maven version to set up               |
+| make-targets    | False    | "all"     | Targets for the make command (e.g.,   |
+|                 |          |           | "clean compile test")                 |
+| env-vars        | False    | "{}"      | Pass GitHub variables as environment  |
+|                 |          |           | variables via `toJSON(vars)` or       |
+|                 |          |           | specific variables in JSON            |
+| env-secrets     | False    | "{}"      | Pass GitHub secrets as environment    |
+|                 |          |           | variables via `toJSON(secrets)` or    |
+|                 |          |           | specific secrets in JSON              |
+| run-jacoco      | False    | "true"    | Boolean defining whether JaCoCo       |
+|                 |          |           | coverage reporting runs               |
+| artifact-upload | False    | "true"    | Upload the JaCoCo badges directory as |
+|                 |          |           | a build artifact                      |
+| artifact-name   | False    | ""        | Uploaded artifact name (default:      |
+|                 |          |           | `maven-make-<job>`)                   |
 
 <!-- markdownlint-enable MD013 -->
 
 ## Outputs
 
-This action does not produce explicit outputs, but generates the following
-artifacts:
+<!-- markdownlint-disable MD013 -->
+
+| Name            | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| coverage        | JaCoCo line coverage percentage (empty when JaCoCo   |
+|                 | did not run)                                         |
+| branch_coverage | JaCoCo branch coverage percentage (empty when JaCoCo |
+|                 | did not run)                                         |
+| artifact_name   | Uploaded build artifact name (empty when disabled)   |
+
+<!-- markdownlint-enable MD013 -->
+
+The action also generates the following artifacts:
 
 - Compiled Maven project artifacts
 - JaCoCo coverage reports (if enabled)
-- JaCoCo coverage badges in `badges/` directory
-- Test results and coverage metrics in logs
+- JaCoCo coverage badges in `badges/` directory, uploaded as a build
+  artifact when `artifact-upload` has the value `true`
+- A build summary table written to `GITHUB_STEP_SUMMARY`
 
 ## Implementation Details
 
@@ -83,7 +99,10 @@ The action performs the following steps:
    specified Make targets
 7. **Coverage Analysis**: Generates JaCoCo coverage badges and reports
    (if enabled)
-8. **Coverage Logging**: Outputs coverage percentages to build logs
+8. **Summary and Outputs**: Publishes coverage outputs and writes a build
+   summary to `GITHUB_STEP_SUMMARY`
+9. **Artifact Upload**: Uploads the `badges/` directory when
+   `artifact-upload` has the value `true`
 
 ## Environment Variables and Secrets
 

--- a/action.yaml
+++ b/action.yaml
@@ -41,6 +41,26 @@ inputs:
     description: "Boolean defining whether Jacoco should be run"
     required: false
     default: "true"
+  artifact-upload:
+    description: "Upload the JaCoCo badges directory as a build artifact"
+    required: false
+    default: "true"
+  artifact-name:
+    description: "Uploaded artifact name (default: maven-make-<job>)"
+    required: false
+    default: ""
+
+outputs:
+  coverage:
+    description: "JaCoCo line coverage % (empty when JaCoCo skipped)"
+    value: ${{ steps.summary.outputs.coverage }}
+  branch_coverage:
+    # yamllint disable-line rule:line-length
+    description: "JaCoCo branch coverage percentage (empty when JaCoCo did not run)"
+    value: ${{ steps.summary.outputs.branch_coverage }}
+  artifact_name:
+    description: "Uploaded build artifact name (empty when disabled)"
+    value: ${{ steps.summary.outputs.artifact_name }}
 
 runs:
   using: "composite"
@@ -108,7 +128,8 @@ runs:
     # yamllint enable rule:line-length
     - name: Generate JaCoCo Badge
       id: jacoco
-      if: ${{ !env.ACT && inputs.run-jacoco }} # skip during local testing
+      # skip during local testing
+      if: ${{ !env.ACT && inputs.run-jacoco == 'true' }}
       # yamllint disable-line rule:line-length
       uses: cicirello/jacoco-badge-generator@72266185b7ee48a6fd74eaf0238395cc8b14fef8 # v2.12.1
       with:
@@ -117,10 +138,76 @@ runs:
         generate-summary: true
         on-missing-report: quiet
 
-    - name: Log coverage percentage
-      id: log-coverage
-      if: ${{ inputs.run-jacoco && steps.jacoco.outcome == 'success' }}
+    - name: 'Generate build summary and outputs'
+      id: summary
       shell: bash
+      env:
+        JDK_VERSION: ${{ inputs.jdk-version }}
+        MVN_VERSION: ${{ inputs.mvn-version }}
+        MAKE_TARGETS: ${{ inputs.make-targets }}
+        RUN_JACOCO: ${{ inputs.run-jacoco }}
+        JACOCO_COVERAGE: ${{ steps.jacoco.outputs.coverage }}
+        JACOCO_BRANCHES: ${{ steps.jacoco.outputs.branches }}
+        ARTIFACT_UPLOAD: ${{ inputs.artifact-upload }}
+        ARTIFACT_NAME_INPUT: ${{ inputs.artifact-name }}
+        JOB_NAME: ${{ github.job }}
       run: |
-        echo "coverage = ${{ steps.jacoco.outputs.coverage }}"
-        echo "branch coverage = ${{ steps.jacoco.outputs.branches }}"
+        # Summarise the build and publish action outputs
+        set -euo pipefail
+
+        # Sanitise a value for embedding in the Markdown summary table:
+        # strip CR/LF (which would break table rows or inject extra lines)
+        # and escape pipe characters (which would create spurious columns).
+        md_cell() {
+          printf '%s' "$1" | tr -d '\r\n' | sed 's/|/\\|/g'
+        }
+
+        ARTIFACT_NAME=""
+        if [ "$ARTIFACT_UPLOAD" = "true" ]; then
+          # Strip CR/LF from the user-provided name first, so a value made
+          # up only of CR/LF cannot slip past the non-empty check and yield
+          # an empty upload-artifact name or inject extra output lines.
+          SANITIZED_NAME=$(printf '%s' "$ARTIFACT_NAME_INPUT" | tr -d '\r\n')
+          if [ -n "$SANITIZED_NAME" ]; then
+            ARTIFACT_NAME="$SANITIZED_NAME"
+          else
+            ARTIFACT_NAME="maven-make-${JOB_NAME}"
+          fi
+        fi
+        # JaCoCo coverage values come from generated report files; strip
+        # CR/LF so they cannot inject extra GITHUB_OUTPUT lines.
+        COVERAGE=$(printf '%s' "$JACOCO_COVERAGE" | tr -d '\r\n')
+        BRANCH_COVERAGE=$(printf '%s' "$JACOCO_BRANCHES" | tr -d '\r\n')
+
+        {
+          echo "coverage=${COVERAGE}"
+          echo "branch_coverage=${BRANCH_COVERAGE}"
+          echo "artifact_name=${ARTIFACT_NAME}"
+        } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "## ☕️ Maven Build (Make) ✅"
+          echo ""
+          echo "| Key | Value |"
+          echo "|-----|-------|"
+          echo "| JDK version | $(md_cell "$JDK_VERSION") |"
+          echo "| Maven version | $(md_cell "$MVN_VERSION") |"
+          echo "| Make targets | $(md_cell "$MAKE_TARGETS") |"
+          if [ "$RUN_JACOCO" = "true" ] && [ -n "$COVERAGE" ]; then
+            echo "| Line coverage | ${COVERAGE}% |"
+            echo "| Branch coverage | ${BRANCH_COVERAGE}% |"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        echo "Line coverage: ${COVERAGE:-n/a}"
+        echo "Branch coverage: ${BRANCH_COVERAGE:-n/a}"
+
+    - name: 'Upload build artifacts'
+      if: ${{ inputs.artifact-upload == 'true' }}
+      # yamllint disable-line rule:line-length
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.summary.outputs.artifact_name }}
+        path: badges/
+        if-no-files-found: ignore
+        retention-days: 7


### PR DESCRIPTION
## Summary

Brings `maven-make-build-action` in line with the enhancements landing
across the Java build blocks (mirrors the `maven-build-action` pattern),
in support of the forthcoming `java-workflows` reusable workflows.

## Changes

- **New action outputs** so downstream steps can consume results:
  - `coverage` — JaCoCo line coverage percentage
  - `branch_coverage` — JaCoCo branch coverage percentage
  - `artifact_name` — uploaded build artifact name (empty when disabled)
- **New inputs**:
  - `artifact-upload` (default `true`) — upload the JaCoCo badges directory
  - `artifact-name` — override the uploaded artifact name
- **Build summary**: a new step writes a table to `GITHUB_STEP_SUMMARY`
  (JDK/Maven version, make targets, coverage).
- **Artifact upload**: uploads `badges/` (SHA-pinned `upload-artifact` v7.0.1,
  `if-no-files-found: ignore`, 7-day retention).

## Fixes

- **JaCoCo truthiness bug**: the badge gate used a bare `inputs.run-jacoco`
  condition, which evaluates truthy even for the string `'false'`. Now
  compares against `'true'` explicitly.
- **Template-injection hardening**: replaced the coverage-logging step (which
  interpolated `steps.jacoco.outputs.*` directly into a `run:` block) with an
  env-indirected summary step.

## Validation

- `yamllint`, `actionlint`, `zizmor --persona=auditor` (zero findings),
  full `prek`, and `markdown-table-fixer` all clean.

## Follow-ups (out of scope)

- `jdk-version` vs `java-version` input-naming inconsistency across the Java
  build actions (tracked as a P1 backlog item).
