### PR TITLE
Feat: Normalise java-version input naming

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: "Running local action: ${{ github.repository }}"
         uses: ./
         with:
-          jdk-version: '21'
+          java-version: '21'
           mvn-version: '3.9.5'
           make-targets: 'build'
           path_prefix: 'oam-oam-controller'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ steps:
     id: maven-make-build
     uses: lfreleng-actions/maven-make-build-action@main
     with:
-      jdk-version: "17"
+      java-version: "17"
       distribution: "temurin"
       mvn-version: "3.8.2"
       make-targets: "clean compile test"
@@ -41,7 +41,8 @@ steps:
 | --------------- | -------- | --------- | ------------------------------------- |
 | path_prefix     | False    | "."       | Directory location containing project |
 |                 |          |           | code                                  |
-| jdk-version     | False    | "17"      | OpenJDK version to set up             |
+| java-version    | False    | "17"      | OpenJDK version to set up             |
+| jdk-version     | False    | ""        | Deprecated alias for java-version     |
 | distribution    | False    | "temurin" | OpenJDK distribution                  |
 | mvn-version     | False    | "3.8.2"   | Maven version to set up               |
 | make-targets    | False    | "all"     | Targets for the make command (e.g.,   |

--- a/action.yaml
+++ b/action.yaml
@@ -11,10 +11,15 @@ inputs:
     description: 'Directory location containing project code'
     required: false
     default: '.'
-  jdk-version:
+  java-version:
     description: "OpenJDK version"
     required: false
     default: "17"
+  jdk-version:
+    # yamllint disable-line rule:line-length
+    description: "Deprecated alias for java-version; retained for backward compatibility"
+    required: false
+    default: ""
   distribution:
     description: "OpenJDK distribution"
     required: false
@@ -77,12 +82,39 @@ runs:
           echo 'Error: invalid path/prefix to project directory ❌'; exit 1
         fi
 
+    - name: 'Resolve Java version'
+      id: java
+      shell: bash
+      env:
+        JAVA_VERSION: ${{ inputs.java-version }}
+        JDK_VERSION_ALIAS: ${{ inputs.jdk-version }}
+      run: |
+        # Resolve the effective Java version. The 'jdk-version' input is a
+        # deprecated alias retained for backward compatibility; when set it
+        # takes precedence over 'java-version' and emits a deprecation
+        # warning so existing callers keep working while they migrate.
+        if [ -n "$JDK_VERSION_ALIAS" ]; then
+          echo "::warning::'jdk-version' is deprecated; use 'java-version'"
+          version="$JDK_VERSION_ALIAS"
+        else
+          version="$JAVA_VERSION"
+        fi
+        # A version string never spans multiple lines; strip any CR/LF so
+        # a crafted value cannot inject extra GITHUB_OUTPUT entries.
+        version=$(printf '%s' "$version" | tr -d '\r\n')
+        if [ -z "$version" ]; then
+          echo "Error: no Java version supplied; set java-version ❌"
+          exit 1
+        fi
+        printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+        echo "Resolved Java version: ${version}"
+
     - name: Setup JDK
       id: setup-jdk
       # yamllint disable-line rule:line-length
       uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
-        java-version: ${{ inputs.jdk-version }}
+        java-version: ${{ steps.java.outputs.version }}
         distribution: ${{ inputs.distribution }}
 
     - name: Setup Maven
@@ -90,7 +122,7 @@ runs:
       # yamllint disable-line rule:line-length
       uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
       with:
-        java-version: ${{ inputs.jdk-version }}
+        java-version: ${{ steps.java.outputs.version }}
         maven-version: ${{ inputs.mvn-version }}
         checkout-enabled: false
 
@@ -142,7 +174,7 @@ runs:
       id: summary
       shell: bash
       env:
-        JDK_VERSION: ${{ inputs.jdk-version }}
+        JDK_VERSION: ${{ steps.java.outputs.version }}
         MVN_VERSION: ${{ inputs.mvn-version }}
         MAKE_TARGETS: ${{ inputs.make-targets }}
         RUN_JACOCO: ${{ inputs.run-jacoco }}


### PR DESCRIPTION
## Summary

Renames the JDK version input on `maven-make-build-action` from
`jdk-version` to `java-version`, aligning it with the sibling Maven
actions (`maven-build-action`, `maven-stage-prep-action`) and the
underlying `actions/setup-java` input of the same name.

This normalisation is deliberately landed **before** the reusable
`lfreleng-actions/java-workflows` wire these actions together: renaming
an input after reusable workflows depend on it would be a breaking
change, so it is much cheaper to settle the naming now.

## Backward compatibility

`jdk-version` is retained as a **deprecated alias** rather than removed:

- A new `Resolve Java version` step computes the effective version.
- When `jdk-version` is set it takes precedence and emits a
  `::warning::` deprecation notice, so existing callers keep working
  while they migrate.
- Otherwise the canonical `java-version` input (default `17`, unchanged)
  is used.

The resolved value feeds both the JDK (`actions/setup-java`) and Maven
(`s4u/setup-maven-action`) setup steps.

## Changes

- `action.yaml`: add canonical `java-version` input; demote
  `jdk-version` to a deprecated alias (default `""`); add the resolve
  step; point both setup steps at the resolved version.
- `README.md`: document `java-version`, mark `jdk-version` deprecated,
  and update the usage example.

## Notes

- The default version value is unchanged (`17`); only the input **name**
  is normalised.
- Two pre-existing `zizmor` template-injection notes on the `main`
  "Log coverage percentage" step are untouched here — they are removed
  by the separate outputs/summary/artifacts PR (#108) which replaces
  that step. This PR introduces no new `zizmor` findings.

Signed-off-by: Matthew Watkins <mwatkins@linuxfoundation.org>